### PR TITLE
fix: Add ALB listener ARNs to outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ preconfigured solution for seamless scalability and high availability."
 
 | Name | Description |
 |------|-------------|
+| <a name="output_aws_lb_listener_arn"></a> [aws\_lb\_listener\_arn](#output\_aws\_lb\_listener\_arn) | ARN of the ALB main listener. |
+| <a name="output_aws_lb_test_listener_arn"></a> [aws\_lb\_test\_listener\_arn](#output\_aws\_lb\_test\_listener\_arn) | ARN of the ALB test listener. |
 | <a name="output_blue_target_group_arn"></a> [blue\_target\_group\_arn](#output\_blue\_target\_group\_arn) | ARN of the blue target group. |
 | <a name="output_cloudwatch_log_group_arn"></a> [cloudwatch\_log\_group\_arn](#output\_cloudwatch\_log\_group\_arn) | ARN of the CloudWatch log group. |
 | <a name="output_codedeploy_app_name"></a> [codedeploy\_app\_name](#output\_codedeploy\_app\_name) | CodeDeploy application name. |

--- a/outputs.tf
+++ b/outputs.tf
@@ -26,6 +26,17 @@ output "green_target_group_arn" {
   value       = aws_lb_target_group.main["green"].arn
 }
 
+## LOAD BALANCER LISTENER
+output "aws_lb_listener_arn" {
+  description = "ARN of the ALB main listener."
+  value       = try(aws_lb_listener.main[0].arn, null)
+}
+
+output "aws_lb_test_listener_arn" {
+  description = "ARN of the ALB test listener."
+  value       = try(aws_lb_listener.test_listener[0].arn, null)
+}
+
 ## TASK DEFINITION
 output "task_definition_arn" {
   description = "ARN of the task definition."


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->

## What it solves

[Add ALB listener ARNs to outputs](https://github.com/geekcell/terraform-aws-ecs-fargate-codedeploy/commit/ab0d52f238ecde5f88a69453d3bc230d366f26b6)

## Readiness Checklist

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request
- [ ] Pull request title is brief and descriptive (for a changelog entry)

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, or `enhancement`
- [ ] Label as `bump:patch`, `bump:minor`, or `bump:major` if this PR should create a new release
