### PR TITLE
fix: alarm configuration showing up in every change set

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ preconfigured solution for seamless scalability and high availability."
 
 ## Resources
 
-- resource.aws_cloudwatch_log_group.main (main.tf#310)
+- resource.aws_cloudwatch_log_group.main (main.tf#313)
 - resource.aws_codedeploy_app.main (main.tf#231)
 - resource.aws_codedeploy_deployment_group.main (main.tf#238)
 - resource.aws_ecs_service.main (main.tf#56)

--- a/main.tf
+++ b/main.tf
@@ -268,10 +268,13 @@ resource "aws_codedeploy_deployment_group" "main" {
     events  = var.codedeploy_auto_rollback_events
   }
 
-  alarm_configuration {
-    enabled                   = length(var.codedeploy_cloudwatch_alarm_names) > 0 ? true : false
-    alarms                    = var.codedeploy_cloudwatch_alarm_names
-    ignore_poll_alarm_failure = var.codedeploy_ignore_poll_alarm_failure
+  dynamic "alarm_configuration" {
+    for_each = length(var.codedeploy_cloudwatch_alarm_names) > 0 ? [true] : []
+
+    content {
+      alarms                    = var.codedeploy_cloudwatch_alarm_names
+      ignore_poll_alarm_failure = var.codedeploy_ignore_poll_alarm_failure
+    }
   }
 
   load_balancer_info {


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->

## What it solves

* Fixes alarm configuration showing up in every changeset if not enabled

## Readiness Checklist

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request
- [ ] Pull request title is brief and descriptive (for a changelog entry)

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, or `enhancement`
- [ ] Label as `bump:patch`, `bump:minor`, or `bump:major` if this PR should create a new release
